### PR TITLE
pfzy 0.3.4  :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,10 +25,15 @@ requirements:
 test:
   imports:
     - pfzy
-  commands:
-    - pip check
   requires:
     - pip
+    - pytest
+    - pytest-asyncio
+  source_files:
+    - tests
+  commands:
+    - pip check
+    - pytest -v tests
 
 about:
   home: https://github.com/kazhala/pfzy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,21 +6,21 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pfzy-{{ version }}.tar.gz
-  sha256: 717ea765dd10b63618e7298b2d98efd819e0b30cd5905c9707223dceeb94b3f1
+  url: https://github.com/kazhala/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 4a36126e045da6471c53e9ea36424296307a1841bd828a41574d7a4aa58dbcea
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.7,<4.0
+    - python
     - pip
-    - poetry
+    - poetry-core
   run:
-    - python >=3.7,<4.0
+    - python
 
 test:
   imports:
@@ -32,10 +32,17 @@ test:
 
 about:
   home: https://github.com/kazhala/pfzy
-  summary: Python port of the fzy fuzzy string matching algorithm
   license: MIT
   license_file: LICENSE
+  license_family: MIT
+  summary: Python port of the fzy fuzzy string matching algorithm.
+  description: |
+    Python port of the fzy fuzzy string matching algorithm.
+  doc_url: https://pfzy.readthedocs.io
+  dev_url: https://github.com/kazhala/pfzy
 
 extra:
   recipe-maintainers:
     - avsthiago
+  skip-lints:
+    - missing_wheel


### PR DESCRIPTION
pfzy 0.3.4  :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4609]
- dev_url (pypi): https://github.com/kazhala/pfzy/tree/0.3.4
- conda-forge: https://github.com/conda-forge/pfzy-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/pfzy/0.3.4
- pypi inspector: https://inspector.pypi.io/project/pfzy/0.3.4
 
### Explanation of changes:

- clean up recipe from CF
- switch to GH release archive, to include tests


[PKG-4609]: https://anaconda.atlassian.net/browse/PKG-4609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ